### PR TITLE
add EMNLP22

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ## Papers
 
 ### 2022
+- <a name="todo"></a> Continual Training of Language Models for Few-Shot Learning (**EMNLP2022**) [[paper](https://arxiv.org/abs/2210.05549)] [[code](https://github.com/UIC-Liu-Lab/CPT)]
 - <a name="todo"></a>On the Effectiveness of Lipschitz-Driven Rehearsal in Continual Learning (**NeurIPS2022**) [[paper](https://arxiv.org/abs/2210.06443)] [[code](https://github.com/aimagelab/LiDER)]
 - <a name="todo"></a>Class-Incremental Continual Learning into the eXtended DER-verse (**TPAMI2022**) [[paper](https://arxiv.org/abs/2201.00766)] [[code](https://github.com/aimagelab/mammoth)]
 - <a name="todo"></a>Few-Shot Class-Incremental Learning by Sampling Multi-Phase Tasks (**TPAMI2022**) [[paper](https://arxiv.org/abs/2203.17030)] [[code](https://github.com/zhoudw-zdw/TPAMI-Limit)]


### PR DESCRIPTION
Add a new paper about continual learning in LM pre-training in EMNLP 2022.