### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 ## Papers
 
 ### 2024
+- <a name = "todo"></a> DELTA: Decoupling Long-Tailed Online Continual Learning (**CVPR2024**) [[paper](https://openaccess.thecvf.com/content/CVPR2024W/CLVISION/papers/Raghavan_DELTA_Decoupling_Long-Tailed_Online_Continual_Learning_CVPRW_2024_paper.pdf)]
 - <a name="todo"></a> Hierarchical Augmentation and Distillation for Class Incremental Audio-Visual Video Recognition (**TPAMI2024**)[[paper](https://ieeexplore.ieee.org/document/10497880)]
 - <a name="todo"></a> Continual Segmentation with Disentangled Objectness Learning and Class Recognition (**CVPR2024**)[[paper](https://arxiv.org/abs/2403.03477)][[code](https://github.com/jordangong/CoMasTRe)]
 - <a name="todo"></a> Interactive Continual Learning: Fast and Slow Thinking (**CVPR2024**)[[paper](https://arxiv.org/abs/2403.02628)][[code](http://github.com/ICL)]


### PR DESCRIPTION
Addition of "DELTA: Decoupling Long-Tailed Online Continual Learning" paper presented at CVPR 2024 in the CLVision workshop. Work presents a decoupling learning technique to improve learning and mitigate forgetting in a long-tailed setting. Additionally, first ever paper to explore multi-exemplar pairing in the context of class incremental learning.